### PR TITLE
crash of Forbes on Matlab 2017a

### DIFF
--- a/library/RiccatiSolve.c
+++ b/library/RiccatiSolve.c
@@ -139,7 +139,7 @@ void RICCATI_SOLVE(int n, int m, int N, double * x, double * w, double * x0_n,
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-    int n, m, N, x_dims[2];
+    int n, m, N;
     double * x, * w, * x0, * A, * B, * LRs, * Ks, * Ms, * Ls;
     double * es, * temp_n;
 
@@ -207,8 +207,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     n = mxGetScalar(prhs[8]);
     m = mxGetScalar(prhs[9]);
     N = mxGetScalar(prhs[10]);
-    x_dims[0] = (N+1)*n+N*m;
-    x_dims[1] = 1;
+    const mwSize x_dims[2] = { n ,1};
     plhs[0] = mxCreateDoubleScalar(0);
     plhs[1] = mxCreateNumericArray(2, x_dims, mxDOUBLE_CLASS, mxREAL);
     x = mxGetPr(plhs[1]);

--- a/private/lbfgs.c
+++ b/private/lbfgs.c
@@ -76,7 +76,7 @@ void LBFGS_MATVEC_TWOLOOP(int n, int mem, double * dir_n, double * s_n_m, double
 
 void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 {
-    int n, mem, curridx, currmem, dir_dims[2];
+    int n, mem, curridx, currmem;
     double * dir, * s, * y, * ys, H, * g, * alpha;
 
     if (nrhs != 7) {
@@ -125,14 +125,11 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 	currmem = (int)mxGetScalar(prhs[6]);
 
     n = mxGetDimensions(prhs[0])[0];
+    const mwSize dir_dims[2] = { n ,1};
     mem = mxGetDimensions(prhs[0])[1];
-    dir_dims[0] = n;
-    dir_dims[1] = 1;
 
 	alpha = mxCalloc(mem, sizeof(double));
 
-    dir_dims[0] = n;
-    dir_dims[1] = 1;
     plhs[0] = mxCreateNumericArray(2, dir_dims, mxDOUBLE_CLASS, mxREAL);
     dir = mxGetPr(plhs[0]);
 


### PR DESCRIPTION
I created an issue about this, but nobody seems to respond.

The mex function uses the wrong type of array.

1. its wasn't const
2.it was int instead of mwSize

More info here: https://nl.mathworks.com/help/matlab/apiref/mxcreatenumericarray.html

Similar things are wrong with the RicattiSolve it crashes too on Matlab2017a. I fixed both of them.